### PR TITLE
Reduce the size of JsonValue.

### DIFF
--- a/code/Core/Json/JsonValue.cpp
+++ b/code/Core/Json/JsonValue.cpp
@@ -53,7 +53,7 @@ namespace Core
 	JsonValue::JsonValue(const std::string& value)
 		: m_type(JsonType::String)
 	{
-		m_value = value;
+		m_value = new std::string(value);
 	}
 
 	JsonValue::JsonValue(JsonObject* pValue)
@@ -107,7 +107,7 @@ namespace Core
 	void JsonValue::Set(const std::string& value)
 	{
 		m_type = JsonType::String;
-		m_value = value;
+		m_value = new std::string(value);
 	}
 
 	void JsonValue::Set(JsonArray* pValue)
@@ -136,6 +136,12 @@ namespace Core
 			delete pObject;
 			m_value = static_cast<JsonObject*>(nullptr);
 		}
+		else if (m_type == JsonType::String)
+		{
+			std::string* pString = std::get<std::string*>(m_value);
+			delete pString;
+			m_value = static_cast<std::string*>(nullptr);
+		}
 	}
 
 	JsonType JsonValue::GetType() const
@@ -153,9 +159,10 @@ namespace Core
 		return std::get<double>(m_value);
 	}
 
-	std::string JsonValue::GetValueAsString() const
+	const std::string& JsonValue::GetValueAsString() const
 	{
-		return std::get<std::string>(m_value);
+		const std::string* pString = std::get<std::string*>(m_value);
+		return *pString;
 	}
 
 	JsonArray* JsonValue::GetValueAsArray() const

--- a/code/Core/Json/JsonValue.cpp
+++ b/code/Core/Json/JsonValue.cpp
@@ -47,7 +47,7 @@ namespace Core
 	JsonValue::JsonValue(const char* pValue)
 		: m_type(JsonType::String)
 	{
-		m_value = pValue;
+		m_value = new std::string(pValue);
 	}
 
 	JsonValue::JsonValue(const std::string& value)

--- a/code/Core/Json/JsonValue.cpp
+++ b/code/Core/Json/JsonValue.cpp
@@ -101,7 +101,12 @@ namespace Core
 	void JsonValue::Set(const char* value)
 	{
 		m_type = JsonType::String;
-		m_value = value;
+		
+		std::string* pString = std::get<std::string*>(m_value);
+		if (pString)
+			*pString = value;
+		else
+			m_value = new std::string(value);
 	}
 
 	void JsonValue::Set(const std::string& value)

--- a/code/Core/Json/JsonValue.h
+++ b/code/Core/Json/JsonValue.h
@@ -45,12 +45,12 @@ namespace Core
 
 		bool GetValueAsBool() const;
 		double GetValueAsDouble() const;
-		std::string GetValueAsString() const;
+		const std::string& GetValueAsString() const;
 		JsonArray* GetValueAsArray() const;
 		JsonObject* GetValueAsObject() const;
 
 	private:
 		JsonType m_type;
-		std::variant<double, std::string, bool, JsonArray*, JsonObject*> m_value;
+		std::variant<double, std::string*, bool, JsonArray*, JsonObject*> m_value;
 	};
 }


### PR DESCRIPTION
Reduce the size of JsonValue using a pointer to a std::string instead of a std::string.