### PR TITLE
[sys] More robust container ids creation.

### DIFF
--- a/code/Editors/MeshEditor/MeshEditor.cpp
+++ b/code/Editors/MeshEditor/MeshEditor.cpp
@@ -67,7 +67,8 @@ namespace Editors
 		FbxImporter::FbxImporter importer;
 		importer.Import(filename, *pMesh);
 	
-		Systems::Container* pContainer = containerMgr.CreateContainer(filename.c_str());
+		Systems::ContainerId cid = assetMgr.GenerateNewContainerId();
+		Systems::Container* pContainer = containerMgr.CreateContainer(cid);
 		pContainer->AddAsset(pMesh);
 
 		Systems::AssetMetadata metadata(pMesh->GetId(), filename, MAKESID("Mesh"));

--- a/code/Systems/Assets/AssetMgr.cpp
+++ b/code/Systems/Assets/AssetMgr.cpp
@@ -11,8 +11,9 @@
 #include "Systems/Assets/AssetType/NewAssetType.h"
 
 #include <assert.h>
+#include <cstdio>
 #include <fstream>
-
+#include <random>
 //#pragma optimize("", off)
 
 namespace Systems
@@ -23,6 +24,7 @@ namespace Systems
 		, m_meshes()
 		, m_materials()
 		, m_nextId()
+		, m_containerIds()
 	{}
 
 	AssetMgr::~AssetMgr()
@@ -357,9 +359,29 @@ namespace Systems
 
 			AssetMetadata metadata(assetId, virtualName, assetTypeSid);
 			m_metadata[assetId] = metadata;
+
+			m_containerIds.insert(assetId.GetContainerId());
 		}
 
 		return true;
+	}
+
+	ContainerId AssetMgr::GenerateNewContainerId()
+	{
+		std::random_device rd;
+		std::mt19937 gen(rd());
+		std::uniform_int_distribution<uint64_t> dis(0, UINT64_MAX);
+
+		ContainerId newId;
+		do
+		{
+			newId = ContainerId(static_cast<uint64_t>(dis(gen)));
+		} 
+		while (m_containerIds.find(newId) != m_containerIds.cend());
+
+		m_containerIds.insert(newId);
+		return newId;
+		
 	}
 
 	std::string AssetMgr::GetMetadataTableFilePath() const

--- a/code/Systems/Assets/AssetMgr.h
+++ b/code/Systems/Assets/AssetMgr.h
@@ -18,6 +18,7 @@
 
 #include <functional>
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -69,6 +70,9 @@ namespace Systems
 		bool SaveMetadataTable() const;
 		bool LoadMetadataTable();
 		
+		//Generate a new unique container id.
+		ContainerId GenerateNewContainerId();
+
 	private:
 		std::string m_root; //location of toc.txt
 		
@@ -85,6 +89,8 @@ namespace Systems
 
 		// New asset system using containers
 		std::map<NewAssetId, AssetMetadata> m_metadata;
+
+		std::set<ContainerId> m_containerIds;
 
 		// New asset types. the type is saved as a string in the metadata table.
 		// It is different from the asset object type. An asset object type can be upgraded and renamed,

--- a/code/Systems/Assets/AssetObjects/AssetUtil.h
+++ b/code/Systems/Assets/AssetObjects/AssetUtil.h
@@ -48,15 +48,18 @@ namespace Systems
 		if (!pAsset)
 			return nullptr;
 
+		AssetMgr& assetMgr = AssetMgr::Get();
+		ContainerId cid = assetMgr.GenerateNewContainerId();
+
 		ContainerMgr& containerMgr = ContainerMgr::Get();
-		Container* pContainer = containerMgr.CreateContainer(virtualName.c_str());
+		Container* pContainer = containerMgr.CreateContainer(cid);
 		pContainer->AddAsset(pAsset);
 		bool res = containerMgr.SaveContainer(pContainer->GetId());
 		if (!res)
 			return nullptr;
 
 		AssetMetadata materialMetadata(pAsset->GetId(), virtualName, T::GetAssetTypeNameSid());
-		AssetMgr& assetMgr = AssetMgr::Get();
+		
 		res = assetMgr.RegisterAssetMetadata(materialMetadata);
 		if (!res)
 			return nullptr;

--- a/code/Systems/Container/ContainerId.h
+++ b/code/Systems/Container/ContainerId.h
@@ -11,7 +11,7 @@ namespace Systems
 {
 	// A container id is a unique identifier for container. It uses the first 56 lsb
 	// which gives us 2^56 possible value.
-	// The top 8 bits are reserved for ObjectId. An ObjectId is local a container and represents
+	// The top 8 bits are reserved for ObjectId. An ObjectId is local to a container and represents
 	// the id of a root object in the package. It means a container can store 2^8 = 256 root objects.
 	// The ObjectId and ContainerId together makes the AssetId.
 	class ContainerId

--- a/code/Systems/Container/ContainerMgr.cpp
+++ b/code/Systems/Container/ContainerMgr.cpp
@@ -42,25 +42,9 @@ namespace Systems
 		m_containerMap.clear();
 	}
 
-	Container* ContainerMgr::CreateContainer(const char* seed)
+	Container* ContainerMgr::CreateContainer(ContainerId cid)
 	{
-		//first make a new container id
-		Core::Sid startSid = SID(seed);
-
-		ContainerId cid(startSid);
-
-		const int MAX_ITERATION = 10000;
-		int ii = 0;
-		std::map<ContainerId, Container*>::const_iterator it = m_containerMap.find(cid);
-		while (it != m_containerMap.cend() && ii < MAX_ITERATION) //boo caca
-		{
-			++ii;
-			++startSid;
-			cid = ContainerId(startSid);
-			it = m_containerMap.find(cid);
-		}
-
-		if (ii >= MAX_ITERATION)
+		if (DoesContainerExistsOnDisk(cid))
 			return nullptr;
 
 		//now create the container
@@ -184,7 +168,14 @@ namespace Systems
 		return true;
 	}
 
-	std::string ContainerMgr::MakeDirectory(ContainerId cid)
+	bool ContainerMgr::DoesContainerExistsOnDisk(ContainerId cid) const
+	{
+		std::string containerFilename = MakeFilename(cid);
+
+		return std::filesystem::exists(containerFilename);
+	}
+
+	std::string ContainerMgr::MakeDirectory(ContainerId cid) const
 	{
 		std::string cidStr = cid.ToString();
 		std::string firstSubFolder = cidStr.substr(2, 2);
@@ -194,7 +185,7 @@ namespace Systems
 		return directory;
 	}
 
-	std::string ContainerMgr::MakeFilename(ContainerId cid)
+	std::string ContainerMgr::MakeFilename(ContainerId cid) const
 	{
 		std::string cidStr = cid.ToString();
 		return MakeDirectory(cid) + cidStr;

--- a/code/Systems/Container/ContainerMgr.h
+++ b/code/Systems/Container/ContainerMgr.h
@@ -23,7 +23,11 @@ namespace Systems
 		void Init(const std::string& root);
 		void Shutdown() override;
 
-		Container* CreateContainer(const char* seed);
+		//Create a new container using the provided container id. If a container already exists on disk using the 
+		//provided container id, the function will fail and return nullptr.
+		Container* CreateContainer(ContainerId cid);
+
+		//Return a pointer to a container. The container needs to have been loaded or created before.
 		Container* GetContainer(ContainerId cid);
 
 		// Delete the container from memory and disk.
@@ -32,11 +36,13 @@ namespace Systems
 		Container* LoadContainer(ContainerId cid);
 		bool SaveContainer(ContainerId cid);
 
+		bool DoesContainerExistsOnDisk(ContainerId cid) const;
+
 	private:
 		std::string m_root;
 		std::map<ContainerId, Container*> m_containerMap;
 
-		std::string MakeDirectory(ContainerId cid);
-		std::string MakeFilename(ContainerId cid);
+		std::string MakeDirectory(ContainerId cid) const;
+		std::string MakeFilename(ContainerId cid) const;
 	};
 }


### PR DESCRIPTION
Container ids generation was broken and they were not unique.
- Asset Mgr:
  - Keep a list of used container ids
  - New function in AssetMgr to generate a new random container id and check it's unique using the container ids list.

I don't need to keep the list of container ids updated on deletion. Next time the engine start, the deleted ids will become available again.