### PR TITLE
[wdg] AbstractViewModel : add BeforeRemoveRows and AfterRemoveRows

### DIFF
--- a/code/Editors/LevelEditor/LevelListModel.cpp
+++ b/code/Editors/LevelEditor/LevelListModel.cpp
@@ -156,9 +156,11 @@ namespace Editors
 		
 		size_t index = std::distance(m_cachedDataArray.begin(), it);
 
+		BeforeRemoveRows(static_cast<int>(index), 1, Widgets::ModelIndex());
+
 		m_cachedDataArray.Erase(it);
 
-		RemoveRows(static_cast<int>(index), 1, Widgets::ModelIndex());
+		AfterRemoveRows(static_cast<int>(index), 1, Widgets::ModelIndex());
 	}
 
 	void LevelListModel::AddCachedData(const Systems::AssetMetadata& metadata)

--- a/code/Editors/MaterialEditor/MaterialListModel.cpp
+++ b/code/Editors/MaterialEditor/MaterialListModel.cpp
@@ -141,6 +141,8 @@ namespace Editors
 		if (cacheIndex < 0)
 			return;
 
+		BeforeRemoveRows(cacheIndex, 1, Widgets::ModelIndex());
+
 		std::vector<CachedShaderData>::const_iterator it = m_cache.cbegin() + cacheIndex;
 		m_cache.erase(it);
 
@@ -161,7 +163,7 @@ namespace Editors
 			}
 		}
 
-		RemoveRows(cacheIndex, 1, Widgets::ModelIndex());
+		AfterRemoveRows(cacheIndex, 1, Widgets::ModelIndex());
 
 		//update the other rows after deletion so the indices are correct
 		if (pMetadata->IsA<Systems::MaterialAsset>())

--- a/code/Widgets/Models/AbstractViewModel.cpp
+++ b/code/Widgets/Models/AbstractViewModel.cpp
@@ -40,10 +40,16 @@ namespace Widgets
 		m_pSelectionModel->CommitInsertRows(start, count, parent);
 	}
 
-	void AbstractViewModel::RemoveRows(int start, int count, const ModelIndex& parent)
+	void AbstractViewModel::BeforeRemoveRows(int start, int count, const ModelIndex& parent)
 	{
 		m_pSelectionModel->BeforeRemoveRows(start, count, parent);
-		m_onRemoveRows(start, count, parent);
+		m_onBeforeRemoveRows(start, count, parent);
 		m_pSelectionModel->AfterRemoveRows(start, count, parent);
+	}
+
+	void AbstractViewModel::AfterRemoveRows(int start, int count, const ModelIndex& parent)
+	{
+		m_pSelectionModel->AfterRemoveRows(start, count, parent);
+		m_onAfterRemoveRows(start, count, parent);
 	}
 }

--- a/code/Widgets/Models/AbstractViewModel.cpp
+++ b/code/Widgets/Models/AbstractViewModel.cpp
@@ -44,12 +44,11 @@ namespace Widgets
 	{
 		m_pSelectionModel->BeforeRemoveRows(start, count, parent);
 		m_onBeforeRemoveRows(start, count, parent);
-		m_pSelectionModel->AfterRemoveRows(start, count, parent);
 	}
 
 	void AbstractViewModel::AfterRemoveRows(int start, int count, const ModelIndex& parent)
 	{
-		m_pSelectionModel->AfterRemoveRows(start, count, parent);
 		m_onAfterRemoveRows(start, count, parent);
+		m_pSelectionModel->AfterRemoveRows(start, count, parent);
 	}
 }

--- a/code/Widgets/Models/AbstractViewModel.h
+++ b/code/Widgets/Models/AbstractViewModel.h
@@ -36,8 +36,11 @@ namespace Widgets
 		//call this after inserting new rows in the model
 		void CommitInsertRows(int start, int count, const ModelIndex& parent);
 
-		//call this after removing the rows from the model
-		void RemoveRows(int start, int count, const ModelIndex& parent);
+		//call this before removing the rows from the model
+		void BeforeRemoveRows(int start, int count, const ModelIndex& parent);
+
+		//call this after the rows were removed from the model
+		void AfterRemoveRows(int start, int count, const ModelIndex& parent);
 
 		//Event called when the model has changed a value and the view needs to be refreshed.
 		EVENT_DECL(DataChanged, void(const ModelIndex& index))
@@ -47,6 +50,7 @@ namespace Widgets
 
 		//Used only by widgets. they need to be friend with this class.
 		PRIVATE_EVENT_DECL(CommitInsertRows, void(int start, int count, const ModelIndex& parent))
-		PRIVATE_EVENT_DECL(RemoveRows, void(int start, int count, const ModelIndex& parent))
+		PRIVATE_EVENT_DECL(BeforeRemoveRows, void(int start, int count, const ModelIndex& parent))
+		PRIVATE_EVENT_DECL(AfterRemoveRows, void(int start, int count, const ModelIndex& parent))
 	};
 }

--- a/code/Widgets/Widgets/TableView.cpp
+++ b/code/Widgets/Widgets/TableView.cpp
@@ -117,8 +117,9 @@ namespace Widgets
 		}
 
 		m_pModel = pModel;
-		m_pModel->OnCommitInsertRows([this](int start, int count, const ModelIndex& parent) { OnCommitInsertRows(start, count, parent); });
-		m_pModel->OnRemoveRows([this](int start, int count, const ModelIndex& parent) { OnRemoveRows(start, count, parent); });
+		m_pModel->OnCommitInsertRows([this](int start, int count, const ModelIndex& parent) { Model_OnCommitInsertRows(start, count, parent); });
+		m_pModel->OnBeforeRemoveRows([this](int start, int count, const ModelIndex& parent) { Model_OnBeforeRemoveRows(start, count, parent); });
+		m_pModel->OnAfterRemoveRows([this](int start, int count, const ModelIndex& parent) { Model_OnAfterRemoveRows(start, count, parent); });
 		m_pModel->OnDataChanged([this](const ModelIndex& index) { OnDataChanged_SelectionModel(index); });
 
 		SelectionModel* pSelectionModel = m_pModel->GetSelectionModel();
@@ -297,7 +298,7 @@ namespace Widgets
 		pLayout->GetDefaultStyle().ShowBorder(false);
 	}
 
-	void TableView::OnCommitInsertRows(int start, int count, const ModelIndex& parent)
+	void TableView::Model_OnCommitInsertRows(int start, int count, const ModelIndex& parent)
 	{
 		//This is a table, only root can have children
 		if (parent.IsValid())
@@ -319,7 +320,7 @@ namespace Widgets
 		Widgets::WidgetMgr::Get().RequestResize();
 	}
 
-	void TableView::OnRemoveRows(int start, int count, const ModelIndex& parent)
+	void TableView::Model_OnBeforeRemoveRows(int start, int count, const ModelIndex& parent)
 	{
 		if (parent.IsValid())
 			return;
@@ -329,7 +330,10 @@ namespace Widgets
 			return;
 
 		m_pLayout->DeleteChild(pLayout);
+	}
 
+	void TableView::Model_OnAfterRemoveRows(int start, int count, const ModelIndex& parent)
+	{
 		WidgetMgr::Get().RequestResize();
 	}
 

--- a/code/Widgets/Widgets/TableView.h
+++ b/code/Widgets/Widgets/TableView.h
@@ -63,8 +63,9 @@ namespace Widgets
 		void SetSelectedRowStyle(int row);
 		void SetDeselectedRowStyle(int row);
 
-		void OnCommitInsertRows(int start, int count, const ModelIndex& parent);
-		void OnRemoveRows(int start, int count, const ModelIndex& parent);
+		void Model_OnCommitInsertRows(int start, int count, const ModelIndex& parent);
+		void Model_OnBeforeRemoveRows(int start, int count, const ModelIndex& parent);
+		void Model_OnAfterRemoveRows(int start, int count, const ModelIndex& parent);
 
 		void OnSelectionChanged_SelectionModel(const std::vector<SelectionRow>& selected, const std::vector<SelectionRow>& deselected);
 		void OnDataChanged_SelectionModel(const ModelIndex& index);


### PR DESCRIPTION
Change the way deletion of rows is handled. Having a single event is ebough for table but not for tree. So now deletion has 2 functions BeforeRemoveRows and AfterRemovesRows.