### PR TITLE
Instanciate level and World

### DIFF
--- a/code/Alpha/Components/PlayerComponent.cpp
+++ b/code/Alpha/Components/PlayerComponent.cpp
@@ -11,6 +11,8 @@
 #include "Rendering/Camera.h"
 
 #include "Systems/Game/GameMgr.h"
+#include "Systems/Game/Subsystems/CameraSubsystem.h"
+#include "Systems/Game/World.h"
 #include "Systems/Objects/GameObject.h"
 
 PlayerComponent::PlayerComponent()
@@ -29,12 +31,12 @@ PlayerComponent::~PlayerComponent()
 void PlayerComponent::PostLoad()
 { }
 
-void PlayerComponent::OnStart()
+void PlayerComponent::OnStart(Systems::World* pWorld)
 {
 	Systems::TransformComponent& transform = GetOwner()->GetTransform();
 	const Core::Mat44f& localTx = transform.GetLocalTx();
 
-	Systems::GameMgr::Get().PushCamera(m_pCamera);
+	pWorld->m_pCameraSubsystem->PushCamera(m_pCamera);
 	m_pCamera->SetLookAt(localTx.GetT() + m_cameraOffset, localTx.GetT(), Core::Vec4f(0, 1, 0, 0));
 	m_pCamera->SetProjection(45 * Core::PI_OVER_180, 1920.f / 1080.f, 0.1f, 1000);
 }
@@ -75,7 +77,7 @@ void PlayerComponent::Update(float dt)
 	}
 }
 
-void PlayerComponent::OnDestroy()
+void PlayerComponent::OnDestroy(Systems::World* pWorld)
 {
-	Systems::GameMgr::Get().PopCamera();
+	pWorld->m_pCameraSubsystem->PopCamera();
 }

--- a/code/Alpha/Components/PlayerComponent.h
+++ b/code/Alpha/Components/PlayerComponent.h
@@ -15,6 +15,11 @@ namespace Rendering
 	class Camera;
 }
 
+namespace Systems
+{
+	class World;
+}
+
 class PlayerComponent : public Systems::GameComponent
 {
 public:
@@ -23,9 +28,9 @@ public:
 
 	void PostLoad() override;
 
-	void OnStart() override;
+	void OnStart(Systems::World* pWorld) override;
 	void Update(float dt) override;
-	void OnDestroy() override;
+	void OnDestroy(Systems::World* pWorld) override;
 
 private:
 

--- a/code/Editors/LevelEditor/LevelEditorModule.cpp
+++ b/code/Editors/LevelEditor/LevelEditorModule.cpp
@@ -14,8 +14,11 @@
 #include "Systems/Assets/AssetMgr.h"
 #include "Systems/Assets/AssetObjects/AssetUtil.h"
 #include "Systems/Game/InstanciateLevel.h"
+#include "Systems/Game/World.h"
+#include "Systems/Game/Subsystems/CameraSubsystem.h"
 #include "Systems/Objects/GameComponent.h"
 #include "Systems/Objects/GameObject.h"
+#include "Systems/Particle/ParticleSystem.h"
 
 //#pragma optimize("", off)
 
@@ -26,6 +29,7 @@ namespace Editors
 		, m_pSelectionMgr(nullptr)
 		, m_loadedLevelAssetId()
 		, m_pLevel(nullptr)
+		, m_pWorld(nullptr)
 	{ }
 
 	LevelEditorModule::~LevelEditorModule()
@@ -34,12 +38,19 @@ namespace Editors
 	void LevelEditorModule::Init()
 	{
 		m_pSelectionMgr = new SelectionMgr();
+
+		m_pWorld = new Systems::World();
+
+		m_pWorld->m_pCameraSubsystem = new Systems::CameraSubsystem();
+		m_pWorld->m_pParticleSystem = new Systems::ParticleSystem();
 	}
 
 	void LevelEditorModule::Shutdown()
 	{
 		delete m_pSelectionMgr;
 		m_pSelectionMgr = nullptr;
+
+		delete m_pWorld;
 	}
 
 	const SelectionMgr* LevelEditorModule::GetConstSelectionMgr() const
@@ -106,7 +117,6 @@ namespace Editors
 			if (!pLevel)
 				return false;
 
-			Systems::InstanciateLevel(pLevel);
 		}
 
 		CloseLevel();
@@ -126,7 +136,6 @@ namespace Editors
 
 		ClearSelection();
 
-		Systems::DeleteInstanciatedLevel(m_pLevel);
 
 		Systems::NewAssetId closedLevel = m_loadedLevelAssetId;
 		m_loadedLevelAssetId = Systems::NewAssetId::INVALID;

--- a/code/Editors/LevelEditor/LevelEditorModule.cpp
+++ b/code/Editors/LevelEditor/LevelEditorModule.cpp
@@ -117,6 +117,7 @@ namespace Editors
 			if (!pLevel)
 				return false;
 
+			Systems::InstanciateLevel(pLevel, m_pWorld);
 		}
 
 		CloseLevel();
@@ -136,6 +137,7 @@ namespace Editors
 
 		ClearSelection();
 
+		Systems::DeleteInstanciatedLevel(m_pLevel, m_pWorld);
 
 		Systems::NewAssetId closedLevel = m_loadedLevelAssetId;
 		m_loadedLevelAssetId = Systems::NewAssetId::INVALID;

--- a/code/Editors/LevelEditor/LevelEditorModule.cpp
+++ b/code/Editors/LevelEditor/LevelEditorModule.cpp
@@ -13,6 +13,7 @@
 
 #include "Systems/Assets/AssetMgr.h"
 #include "Systems/Assets/AssetObjects/AssetUtil.h"
+#include "Systems/Game/InstanciateLevel.h"
 #include "Systems/Objects/GameComponent.h"
 #include "Systems/Objects/GameObject.h"
 
@@ -98,9 +99,15 @@ namespace Editors
 		if (m_loadedLevelAssetId == id)
 			return false;
 
-		Systems::LevelAsset* pLevel = Systems::AssetUtil::LoadAsset<Systems::LevelAsset>(id, Systems::LoadingDomain::EDITOR);
+		Systems::LevelAsset* pLevel = Systems::AssetUtil::GetAsset<Systems::LevelAsset>(id, Systems::LoadingDomain::EDITOR);
 		if (!pLevel)
-			return false;
+		{
+			pLevel = Systems::AssetUtil::LoadAsset<Systems::LevelAsset>(id, Systems::LoadingDomain::EDITOR);
+			if (!pLevel)
+				return false;
+
+			Systems::InstanciateLevel(pLevel);
+		}
 
 		CloseLevel();
 

--- a/code/Editors/LevelEditor/LevelEditorModule.cpp
+++ b/code/Editors/LevelEditor/LevelEditorModule.cpp
@@ -126,6 +126,8 @@ namespace Editors
 
 		ClearSelection();
 
+		Systems::DeleteInstanciatedLevel(m_pLevel);
+
 		Systems::NewAssetId closedLevel = m_loadedLevelAssetId;
 		m_loadedLevelAssetId = Systems::NewAssetId::INVALID;
 		m_pLevel = nullptr;

--- a/code/Editors/LevelEditor/LevelEditorModule.h
+++ b/code/Editors/LevelEditor/LevelEditorModule.h
@@ -29,6 +29,7 @@ namespace Rendering
 namespace Systems
 {
 	class AssetMetadata;
+	class World;
 }
 
 namespace Widgets
@@ -106,6 +107,8 @@ namespace Editors
 		EVENT_DECL(ReparentGameObject, void(const Systems::GameObject* pGo, const Systems::GameObject* pOldParent, const Systems::GameObject* pNewParent))
 
 	private:
+		Systems::World* m_pWorld;
+
 		SelectionMgr* m_pSelectionMgr;
 
 		Systems::NewAssetId m_loadedLevelAssetId;

--- a/code/Systems/Game/GameMgr.cpp
+++ b/code/Systems/Game/GameMgr.cpp
@@ -173,16 +173,11 @@ namespace Systems
 					assert(false && "Tried to load a level that doesn't exist");
 					return; //doesn't exist
 				}
-
-				InstanciateLevel(pLevel);
 			}
 
 			m_loadedLevels.PushBack(pLevel);
 
-			const Core::Array<GameObject*>& gameObjects = pLevel->GetGameObjectsArray();
-			for (GameObject* pGo : gameObjects)
-				pGo->OnStart();
-
+			InstanciateLevel(pLevel);
 		}
 
 		m_loadingRequest.Clear();
@@ -202,9 +197,7 @@ namespace Systems
 				return; //doesn't exist
 			}
 
-			const Core::Array<GameObject*>& gameObjects = pLevel->GetGameObjectsArray();
-			for (GameObject* pGo : gameObjects)
-				pGo->OnDestroy();
+			DeleteInstanciatedLevel(pLevel);
 
 			Systems::AssetUtil::UnloadAsset(id, Systems::LoadingDomain::GAME);
 

--- a/code/Systems/Game/GameMgr.cpp
+++ b/code/Systems/Game/GameMgr.cpp
@@ -11,6 +11,7 @@
 
 #include "Systems/Assets/AssetObjects/AssetUtil.h"
 #include "Systems/Assets/AssetObjects/Level/LevelAsset.h"
+#include "Systems/Game/InstanciateLevel.h"
 #include "Systems/Objects/GameObject.h"
 #include "Systems/Rendering/Renderable/RenderableScene.h"
 #include "Systems/Rendering/RenderPass/RenderPassBase.h"
@@ -163,11 +164,17 @@ namespace Systems
 			if (IsLevelAlreadyLoaded(id))
 				continue;
 
-			Systems::LevelAsset* pLevel = Systems::AssetUtil::LoadAsset<Systems::LevelAsset>(id, Systems::LoadingDomain::GAME);
+			Systems::LevelAsset* pLevel = Systems::AssetUtil::GetAsset<Systems::LevelAsset>(id, Systems::LoadingDomain::GAME);
 			if (!pLevel)
 			{
-				assert(false && "Tried to load a level that doesn't exist");
-				return; //doesn't exist
+				pLevel = Systems::AssetUtil::LoadAsset<Systems::LevelAsset>(id, Systems::LoadingDomain::GAME);
+				if (!pLevel)
+				{
+					assert(false && "Tried to load a level that doesn't exist");
+					return; //doesn't exist
+				}
+
+				InstanciateLevel(pLevel);
 			}
 
 			m_loadedLevels.PushBack(pLevel);

--- a/code/Systems/Game/GameMgr.cpp
+++ b/code/Systems/Game/GameMgr.cpp
@@ -17,6 +17,7 @@
 #include "Systems/Rendering/RenderPass/RenderPassBase.h"
 #include "Systems/Rendering/RenderPass/RenderPassBloom.h"
 #include "Systems/Rendering/RenderPass/RenderPassShadowMaps.h"
+#include "Systems/Game/Subsystems/CameraSubsystem.h"
 
 namespace Systems
 {
@@ -26,6 +27,7 @@ namespace Systems
 		, m_pRenderPassShadowMaps(nullptr)
 		, m_pRenderPassBloom(nullptr)
 		, m_pDefaultCamera(nullptr)
+		, m_pCameraSubsystem(nullptr)
 	{ }
 
 	GameMgr::~GameMgr()
@@ -50,7 +52,9 @@ namespace Systems
 		m_pDefaultCamera = new Rendering::Camera();
 		m_pDefaultCamera->SetLookAt(Core::Vec4f(0, 10, -10, 1), Core::Vec4f(0, 0, 0, 1), Core::Vec4f(0, 1, 0, 0));
 		m_pDefaultCamera->SetProjection(45 * Core::PI_OVER_180, RATIO, 0.1f, 1000);
-		m_cameraStack.push(m_pDefaultCamera);
+
+		m_pCameraSubsystem = new CameraSubsystem();
+		m_pCameraSubsystem->PushCamera(m_pDefaultCamera);
 	}
 
 	void GameMgr::Release()
@@ -59,6 +63,7 @@ namespace Systems
 		delete m_pRenderPassShadowMaps;
 		delete m_pRenderPassBloom;
 		delete m_pDefaultCamera;
+		delete m_pCameraSubsystem;
 	}
 
 	void GameMgr::Update(float dt)
@@ -83,7 +88,7 @@ namespace Systems
 	{
 		Systems::RenderableScene scene;
 
-		const Rendering::Camera* pCamera = m_cameraStack.top();
+		const Rendering::Camera* pCamera = m_pCameraSubsystem->GetTopCamera();
 		Systems::PrepareRenderableCamera(pCamera->GetViewMatrix(), pCamera->GetProjectionMatrix(), pCamera->GetPosition(), pCamera->GetFOV(), scene);
 
 		for (Systems::LevelAsset* pLevel : m_loadedLevels)
@@ -133,12 +138,12 @@ namespace Systems
 
 	void GameMgr::PushCamera(Rendering::Camera* pCamera)
 	{
-		m_cameraStack.push(pCamera);
+		m_pCameraSubsystem->PushCamera(pCamera);
 	}
 
 	void GameMgr::PopCamera()
 	{
-		m_cameraStack.pop();
+		m_pCameraSubsystem->PopCamera();
 	}
 
 	Rendering::RenderTarget* GameMgr::GetFinalRenderTarget()

--- a/code/Systems/Game/GameMgr.cpp
+++ b/code/Systems/Game/GameMgr.cpp
@@ -187,7 +187,7 @@ namespace Systems
 
 			m_loadedLevels.PushBack(pLevel);
 
-			InstanciateLevel(pLevel);
+			InstanciateLevel(pLevel, m_pWorld);
 		}
 
 		m_loadingRequest.Clear();
@@ -207,7 +207,7 @@ namespace Systems
 				return; //doesn't exist
 			}
 
-			DeleteInstanciatedLevel(pLevel);
+			DeleteInstanciatedLevel(pLevel, m_pWorld);
 
 			Systems::AssetUtil::UnloadAsset(id, Systems::LoadingDomain::GAME);
 

--- a/code/Systems/Game/GameMgr.cpp
+++ b/code/Systems/Game/GameMgr.cpp
@@ -13,11 +13,13 @@
 #include "Systems/Assets/AssetObjects/Level/LevelAsset.h"
 #include "Systems/Game/InstanciateLevel.h"
 #include "Systems/Objects/GameObject.h"
+#include "Systems/Particle/ParticleSystem.h"
 #include "Systems/Rendering/Renderable/RenderableScene.h"
 #include "Systems/Rendering/RenderPass/RenderPassBase.h"
 #include "Systems/Rendering/RenderPass/RenderPassBloom.h"
 #include "Systems/Rendering/RenderPass/RenderPassShadowMaps.h"
 #include "Systems/Game/Subsystems/CameraSubsystem.h"
+#include "Systems/Game/World.h"
 
 namespace Systems
 {
@@ -27,7 +29,7 @@ namespace Systems
 		, m_pRenderPassShadowMaps(nullptr)
 		, m_pRenderPassBloom(nullptr)
 		, m_pDefaultCamera(nullptr)
-		, m_pCameraSubsystem(nullptr)
+		, m_pWorld(nullptr)
 	{ }
 
 	GameMgr::~GameMgr()
@@ -53,8 +55,11 @@ namespace Systems
 		m_pDefaultCamera->SetLookAt(Core::Vec4f(0, 10, -10, 1), Core::Vec4f(0, 0, 0, 1), Core::Vec4f(0, 1, 0, 0));
 		m_pDefaultCamera->SetProjection(45 * Core::PI_OVER_180, RATIO, 0.1f, 1000);
 
-		m_pCameraSubsystem = new CameraSubsystem();
-		m_pCameraSubsystem->PushCamera(m_pDefaultCamera);
+		m_pWorld = new World();
+		m_pWorld->m_pCameraSubsystem = new CameraSubsystem();
+		m_pWorld->m_pCameraSubsystem->PushCamera(m_pDefaultCamera);
+
+		m_pWorld->m_pParticleSystem = new ParticleSystem();
 	}
 
 	void GameMgr::Release()
@@ -63,7 +68,7 @@ namespace Systems
 		delete m_pRenderPassShadowMaps;
 		delete m_pRenderPassBloom;
 		delete m_pDefaultCamera;
-		delete m_pCameraSubsystem;
+		delete m_pWorld;
 	}
 
 	void GameMgr::Update(float dt)
@@ -88,7 +93,7 @@ namespace Systems
 	{
 		Systems::RenderableScene scene;
 
-		const Rendering::Camera* pCamera = m_pCameraSubsystem->GetTopCamera();
+		const Rendering::Camera* pCamera = m_pWorld->m_pCameraSubsystem->GetTopCamera();
 		Systems::PrepareRenderableCamera(pCamera->GetViewMatrix(), pCamera->GetProjectionMatrix(), pCamera->GetPosition(), pCamera->GetFOV(), scene);
 
 		for (Systems::LevelAsset* pLevel : m_loadedLevels)
@@ -138,12 +143,12 @@ namespace Systems
 
 	void GameMgr::PushCamera(Rendering::Camera* pCamera)
 	{
-		m_pCameraSubsystem->PushCamera(pCamera);
+		m_pWorld->m_pCameraSubsystem->PushCamera(pCamera);
 	}
 
 	void GameMgr::PopCamera()
 	{
-		m_pCameraSubsystem->PopCamera();
+		m_pWorld->m_pCameraSubsystem->PopCamera();
 	}
 
 	Rendering::RenderTarget* GameMgr::GetFinalRenderTarget()

--- a/code/Systems/Game/GameMgr.cpp
+++ b/code/Systems/Game/GameMgr.cpp
@@ -141,16 +141,6 @@ namespace Systems
 			m_unloadingRequest.PushBack(pLevel->GetId());
 	}
 
-	void GameMgr::PushCamera(Rendering::Camera* pCamera)
-	{
-		m_pWorld->m_pCameraSubsystem->PushCamera(pCamera);
-	}
-
-	void GameMgr::PopCamera()
-	{
-		m_pWorld->m_pCameraSubsystem->PopCamera();
-	}
-
 	Rendering::RenderTarget* GameMgr::GetFinalRenderTarget()
 	{
 		return m_pRenderPassBase->GetRenderTarget();

--- a/code/Systems/Game/GameMgr.h
+++ b/code/Systems/Game/GameMgr.h
@@ -19,6 +19,7 @@ namespace Rendering
 
 namespace Systems
 {
+	class CameraSubsystem;
 	class GameObject;
 	class LevelAsset;
 	class RenderPassBase;
@@ -62,8 +63,9 @@ namespace Systems
 		//Camera
 		Rendering::Camera* m_pDefaultCamera;
 
+		CameraSubsystem* m_pCameraSubsystem;
 		//Stack of camera. The currently active camera is the one at the top. There is always a default camera.
-		std::stack<Rendering::Camera*> m_cameraStack;
+		//std::stack<Rendering::Camera*> m_cameraStack;
 
 		bool IsLevelAlreadyLoaded(Systems::NewAssetId id) const;
 

--- a/code/Systems/Game/GameMgr.h
+++ b/code/Systems/Game/GameMgr.h
@@ -25,6 +25,7 @@ namespace Systems
 	class RenderPassBase;
 	class RenderPassBloom;
 	class RenderPassShadowMaps;
+	class World;
 
 	class GameMgr : public Core::Singleton<GameMgr>
 	{
@@ -63,9 +64,7 @@ namespace Systems
 		//Camera
 		Rendering::Camera* m_pDefaultCamera;
 
-		CameraSubsystem* m_pCameraSubsystem;
-		//Stack of camera. The currently active camera is the one at the top. There is always a default camera.
-		//std::stack<Rendering::Camera*> m_cameraStack;
+		World* m_pWorld;
 
 		bool IsLevelAlreadyLoaded(Systems::NewAssetId id) const;
 

--- a/code/Systems/Game/GameMgr.h
+++ b/code/Systems/Game/GameMgr.h
@@ -44,9 +44,6 @@ namespace Systems
 
 		void RequestUnloadingAllLevels();
 
-		void PushCamera(Rendering::Camera* pCamera);
-		void PopCamera();
-
 		Rendering::RenderTarget* GetFinalRenderTarget();
 
 	private:

--- a/code/Systems/Game/InstanciateLevel.cpp
+++ b/code/Systems/Game/InstanciateLevel.cpp
@@ -9,17 +9,17 @@
 
 namespace Systems
 {
-	void InstanciateLevel(LevelAsset* pLevel)
+	void InstanciateLevel(LevelAsset* pLevel, World* pWorld)
 	{
 		Core::Array<GameObject*>& objectArray = pLevel->GetGameObjectsArray();
 		for (GameObject* pObject : objectArray)
-			pObject->OnStart();
+			pObject->OnStart(pWorld);
 	}
 
-	void DeleteInstanciatedLevel(LevelAsset* pLevel)
+	void DeleteInstanciatedLevel(LevelAsset* pLevel, World* pWorld)
 	{
 		Core::Array<GameObject*>& objectArray = pLevel->GetGameObjectsArray();
 		for (GameObject* pObject : objectArray)
-			pObject->OnDestroy();
+			pObject->OnDestroy(pWorld);
 	}
 }

--- a/code/Systems/Game/InstanciateLevel.cpp
+++ b/code/Systems/Game/InstanciateLevel.cpp
@@ -13,6 +13,13 @@ namespace Systems
 	{
 		Core::Array<GameObject*>& objectArray = pLevel->GetGameObjectsArray();
 		for (GameObject* pObject : objectArray)
-			pObject->Instanciate();
+			pObject->OnStart();
+	}
+
+	void DeleteInstanciatedLevel(LevelAsset* pLevel)
+	{
+		Core::Array<GameObject*>& objectArray = pLevel->GetGameObjectsArray();
+		for (GameObject* pObject : objectArray)
+			pObject->OnDestroy();
 	}
 }

--- a/code/Systems/Game/InstanciateLevel.cpp
+++ b/code/Systems/Game/InstanciateLevel.cpp
@@ -1,0 +1,18 @@
+/********************************************************************************/
+/* Copyright (C) 2026 Florent Devillechabrol <florent.devillechabrol@gmail.com>	*/
+/********************************************************************************/
+
+#include "Systems/Game/InstanciateLevel.h"
+
+#include "Systems/Assets/AssetObjects/Level/LevelAsset.h"
+#include "Systems/Objects/GameObject.h"
+
+namespace Systems
+{
+	void InstanciateLevel(LevelAsset* pLevel)
+	{
+		Core::Array<GameObject*>& objectArray = pLevel->GetGameObjectsArray();
+		for (GameObject* pObject : objectArray)
+			pObject->Instanciate();
+	}
+}

--- a/code/Systems/Game/InstanciateLevel.h
+++ b/code/Systems/Game/InstanciateLevel.h
@@ -7,7 +7,8 @@
 namespace Systems
 {
 	class LevelAsset;
+	class World;
 
-	void InstanciateLevel(LevelAsset* pLevel);
-	void DeleteInstanciatedLevel(LevelAsset* pLevel);
+	void InstanciateLevel(LevelAsset* pLevel, World* pWorld);
+	void DeleteInstanciatedLevel(LevelAsset* pLevel, World* pWorld);
 }

--- a/code/Systems/Game/InstanciateLevel.h
+++ b/code/Systems/Game/InstanciateLevel.h
@@ -1,0 +1,12 @@
+/********************************************************************************/
+/* Copyright (C) 2026 Florent Devillechabrol <florent.devillechabrol@gmail.com>	*/
+/********************************************************************************/
+
+#pragma once
+
+namespace Systems
+{
+	class LevelAsset;
+
+	void InstanciateLevel(LevelAsset* pLevel);
+}

--- a/code/Systems/Game/InstanciateLevel.h
+++ b/code/Systems/Game/InstanciateLevel.h
@@ -9,4 +9,5 @@ namespace Systems
 	class LevelAsset;
 
 	void InstanciateLevel(LevelAsset* pLevel);
+	void DeleteInstanciatedLevel(LevelAsset* pLevel);
 }

--- a/code/Systems/Game/Subsystems/CameraSubsystem.cpp
+++ b/code/Systems/Game/Subsystems/CameraSubsystem.cpp
@@ -1,0 +1,30 @@
+/********************************************************************************/
+/* Copyright (C) 2026 Florent Devillechabrol <florent.devillechabrol@gmail.com>	*/
+/********************************************************************************/
+
+#include "Systems/Game/Subsystems/CameraSubsystem.h"
+
+namespace Systems
+{
+	CameraSubsystem::CameraSubsystem()
+		: m_cameraStack()
+	{ }
+
+	CameraSubsystem::~CameraSubsystem()
+	{ }
+
+	void CameraSubsystem::PushCamera(Rendering::Camera* pCamera)
+	{
+		m_cameraStack.push(pCamera);
+	}
+
+	void CameraSubsystem::PopCamera()
+	{
+		m_cameraStack.pop();
+	}
+
+	const Rendering::Camera* CameraSubsystem::GetTopCamera() const
+	{
+		return m_cameraStack.top();
+	}
+}

--- a/code/Systems/Game/Subsystems/CameraSubsystem.h
+++ b/code/Systems/Game/Subsystems/CameraSubsystem.h
@@ -1,0 +1,31 @@
+/********************************************************************************/
+/* Copyright (C) 2026 Florent Devillechabrol <florent.devillechabrol@gmail.com>	*/
+/********************************************************************************/
+
+#pragma once
+
+#include <stack>
+
+namespace Rendering
+{
+	class Camera;
+}
+
+namespace Systems
+{
+	class CameraSubsystem
+	{
+	public:
+		CameraSubsystem();
+		~CameraSubsystem();
+
+		void PushCamera(Rendering::Camera* pCamera);
+		void PopCamera();
+
+		const Rendering::Camera* GetTopCamera() const;
+
+	private:
+		//Stack of camera. The currently active camera is the one at the top. There is always a default camera.
+		std::stack<Rendering::Camera*> m_cameraStack;
+	};
+}

--- a/code/Systems/Game/World.cpp
+++ b/code/Systems/Game/World.cpp
@@ -4,16 +4,19 @@
 
 #include "Systems/Game/World.h"
 
+#include "Systems/Game/Subsystems/CameraSubsystem.h"
 #include "Systems/Particle/ParticleSystem.h"
 
 namespace Systems
 {
 	World::World()
 		: m_pParticleSystem(nullptr)
+		, m_pCameraSubsystem(nullptr)
 	{ }
 
 	World::~World()
 	{
 		delete m_pParticleSystem;
+		delete m_pCameraSubsystem;
 	}
 }

--- a/code/Systems/Game/World.cpp
+++ b/code/Systems/Game/World.cpp
@@ -1,0 +1,19 @@
+/********************************************************************************/
+/* Copyright (C) 2026 Florent Devillechabrol <florent.devillechabrol@gmail.com>	*/
+/********************************************************************************/
+
+#include "Systems/Game/World.h"
+
+#include "Systems/Particle/ParticleSystem.h"
+
+namespace Systems
+{
+	World::World()
+		: m_pParticleSystem(nullptr)
+	{ }
+
+	World::~World()
+	{
+		delete m_pParticleSystem;
+	}
+}

--- a/code/Systems/Game/World.h
+++ b/code/Systems/Game/World.h
@@ -6,6 +6,7 @@
 
 namespace Systems
 {
+	class CameraSubsystem;
 	class ParticleSystem;
 
 	//This represent an instance of all the subsystems used by the game. We can have multiple worlds at the same time
@@ -17,6 +18,7 @@ namespace Systems
 		World();
 		~World();
 
+		CameraSubsystem* m_pCameraSubsystem;
 		ParticleSystem* m_pParticleSystem;
 	};
 }

--- a/code/Systems/Game/World.h
+++ b/code/Systems/Game/World.h
@@ -1,0 +1,22 @@
+/********************************************************************************/
+/* Copyright (C) 2026 Florent Devillechabrol <florent.devillechabrol@gmail.com>	*/
+/********************************************************************************/
+
+#pragma once
+
+namespace Systems
+{
+	class ParticleSystem;
+
+	//This represent an instance of all the subsystems used by the game. We can have multiple worlds at the same time
+	//for example one for the game and one for the level editor.
+	//The world owns the systems so it deletes them in the destructor
+	class World
+	{
+	public:
+		World();
+		~World();
+
+		ParticleSystem* m_pParticleSystem;
+	};
+}

--- a/code/Systems/Objects/GameComponent.cpp
+++ b/code/Systems/Objects/GameComponent.cpp
@@ -24,6 +24,9 @@ namespace Systems
 	void GameComponent::OnDestroy()
 	{ }
 
+	void GameComponent::Instanciate()
+	{ }
+
 	void GameComponent::SetGuid(const Core::Guid& guid)
 	{
 		m_guid = guid;

--- a/code/Systems/Objects/GameComponent.cpp
+++ b/code/Systems/Objects/GameComponent.cpp
@@ -15,13 +15,13 @@ namespace Systems
 	GameComponent::~GameComponent()
 	{ }
 
-	void GameComponent::OnStart()
+	void GameComponent::OnStart(World* pWorld)
 	{ }
 
 	void GameComponent::Update(float dt)
 	{ }
 
-	void GameComponent::OnDestroy()
+	void GameComponent::OnDestroy(World* pWorld)
 	{ }
 
 	void GameComponent::SetGuid(const Core::Guid& guid)

--- a/code/Systems/Objects/GameComponent.cpp
+++ b/code/Systems/Objects/GameComponent.cpp
@@ -24,9 +24,6 @@ namespace Systems
 	void GameComponent::OnDestroy()
 	{ }
 
-	void GameComponent::Instanciate()
-	{ }
-
 	void GameComponent::SetGuid(const Core::Guid& guid)
 	{
 		m_guid = guid;

--- a/code/Systems/Objects/GameComponent.h
+++ b/code/Systems/Objects/GameComponent.h
@@ -25,6 +25,8 @@ namespace Systems
 		virtual void Update(float dt);
 		virtual void OnDestroy();
 
+		virtual void Instanciate();
+
 		void SetGuid(const Core::Guid& guid);
 
 		void SetOwner(GameObject* pOwnerGo);

--- a/code/Systems/Objects/GameComponent.h
+++ b/code/Systems/Objects/GameComponent.h
@@ -25,8 +25,6 @@ namespace Systems
 		virtual void Update(float dt);
 		virtual void OnDestroy();
 
-		virtual void Instanciate();
-
 		void SetGuid(const Core::Guid& guid);
 
 		void SetOwner(GameObject* pOwnerGo);

--- a/code/Systems/Objects/GameComponent.h
+++ b/code/Systems/Objects/GameComponent.h
@@ -14,6 +14,7 @@ ENABLE_REFLECTION(Systems, GameComponent)
 namespace Systems
 {
 	class GameObject;
+	class World;
 
 	class GameComponent : public Object
 	{
@@ -21,9 +22,9 @@ namespace Systems
 		GameComponent();
 		~GameComponent();
 
-		virtual void OnStart();
+		virtual void OnStart(World* pWorld);
 		virtual void Update(float dt);
-		virtual void OnDestroy();
+		virtual void OnDestroy(World* pWorld);
 
 		void SetGuid(const Core::Guid& guid);
 

--- a/code/Systems/Objects/GameObject.cpp
+++ b/code/Systems/Objects/GameObject.cpp
@@ -22,10 +22,10 @@ namespace Systems
 		m_components.Clear();
 	}
 
-	void GameObject::OnStart()
+	void GameObject::OnStart(World* pWorld)
 	{
 		for (GameComponent* pComponent : m_components)
-			pComponent->OnStart();
+			pComponent->OnStart(pWorld);
 	}
 
 	void GameObject::Update(float dt)
@@ -39,10 +39,10 @@ namespace Systems
 		m_transform.Update(0);
 	}
 
-	void GameObject::OnDestroy()
+	void GameObject::OnDestroy(World* pWorld)
 	{
 		for (GameComponent* pComponent : m_components)
-			pComponent->OnDestroy();
+			pComponent->OnDestroy(pWorld);
 	}
 
 	void GameObject::SetGuid(const Core::Guid& guid)

--- a/code/Systems/Objects/GameObject.cpp
+++ b/code/Systems/Objects/GameObject.cpp
@@ -45,12 +45,6 @@ namespace Systems
 			pComponent->OnDestroy();
 	}
 
-	void GameObject::Instanciate()
-	{
-		for (GameComponent* pComponent : m_components)
-			pComponent->Instanciate();
-	}
-
 	void GameObject::SetGuid(const Core::Guid& guid)
 	{
 		m_guid = guid;

--- a/code/Systems/Objects/GameObject.cpp
+++ b/code/Systems/Objects/GameObject.cpp
@@ -45,6 +45,12 @@ namespace Systems
 			pComponent->OnDestroy();
 	}
 
+	void GameObject::Instanciate()
+	{
+		for (GameComponent* pComponent : m_components)
+			pComponent->Instanciate();
+	}
+
 	void GameObject::SetGuid(const Core::Guid& guid)
 	{
 		m_guid = guid;

--- a/code/Systems/Objects/GameObject.h
+++ b/code/Systems/Objects/GameObject.h
@@ -36,9 +36,6 @@ namespace Systems
 		//Called before deleting the gameobjet after the last Update.
 		virtual void OnDestroy();
 
-		//Called when the game object is added to a world
-		virtual void Instanciate();
-
 		void SetGuid(const Core::Guid& guid);
 		const Core::Guid& GetGuid() const;
 

--- a/code/Systems/Objects/GameObject.h
+++ b/code/Systems/Objects/GameObject.h
@@ -17,6 +17,7 @@ ENABLE_REFLECTION(Systems, GameObject)
 namespace Systems
 {
 	class GameComponent;
+	class World;
 
 	class GameObject : public Object
 	{
@@ -27,14 +28,14 @@ namespace Systems
 		virtual ~GameObject();
 
 		//Called only once before the first Update.
-		virtual void OnStart();
+		virtual void OnStart(World* pWorld);
 
 		//Called every frame
 		virtual void Update(float dt);
 		virtual void UpdateTransform();
 
 		//Called before deleting the gameobjet after the last Update.
-		virtual void OnDestroy();
+		virtual void OnDestroy(World* pWorld);
 
 		void SetGuid(const Core::Guid& guid);
 		const Core::Guid& GetGuid() const;

--- a/code/Systems/Objects/GameObject.h
+++ b/code/Systems/Objects/GameObject.h
@@ -36,6 +36,9 @@ namespace Systems
 		//Called before deleting the gameobjet after the last Update.
 		virtual void OnDestroy();
 
+		//Called when the game object is added to a world
+		virtual void Instanciate();
+
 		void SetGuid(const Core::Guid& guid);
 		const Core::Guid& GetGuid() const;
 

--- a/code/Systems/Systems.vcxproj
+++ b/code/Systems/Systems.vcxproj
@@ -43,6 +43,7 @@
     <ClInclude Include="GameComponent\SkyboxComponent.h" />
     <ClInclude Include="GameComponent\StaticMeshComponent.h" />
     <ClInclude Include="Game\GameMgr.h" />
+    <ClInclude Include="Game\InstanciateLevel.h" />
     <ClInclude Include="Objects\AssetObject.h" />
     <ClInclude Include="Objects\GameComponent.h" />
     <ClInclude Include="Objects\GameObject.h" />
@@ -97,6 +98,7 @@
     <ClCompile Include="GameComponent\StaticMeshComponent.cpp" />
     <ClCompile Include="GameComponent\TransformComponent.cpp" />
     <ClCompile Include="Game\GameMgr.cpp" />
+    <ClCompile Include="Game\InstanciateLevel.cpp" />
     <ClCompile Include="Objects\AssetObject.cpp" />
     <ClCompile Include="Objects\GameComponent.cpp" />
     <ClCompile Include="Objects\GameObject.cpp" />

--- a/code/Systems/Systems.vcxproj
+++ b/code/Systems/Systems.vcxproj
@@ -44,6 +44,7 @@
     <ClInclude Include="GameComponent\StaticMeshComponent.h" />
     <ClInclude Include="Game\GameMgr.h" />
     <ClInclude Include="Game\InstanciateLevel.h" />
+    <ClInclude Include="Game\Subsystems\CameraSubsystem.h" />
     <ClInclude Include="Game\World.h" />
     <ClInclude Include="Objects\AssetObject.h" />
     <ClInclude Include="Objects\GameComponent.h" />
@@ -100,6 +101,7 @@
     <ClCompile Include="GameComponent\TransformComponent.cpp" />
     <ClCompile Include="Game\GameMgr.cpp" />
     <ClCompile Include="Game\InstanciateLevel.cpp" />
+    <ClCompile Include="Game\Subsystems\CameraSubsystem.cpp" />
     <ClCompile Include="Game\World.cpp" />
     <ClCompile Include="Objects\AssetObject.cpp" />
     <ClCompile Include="Objects\GameComponent.cpp" />

--- a/code/Systems/Systems.vcxproj
+++ b/code/Systems/Systems.vcxproj
@@ -44,6 +44,7 @@
     <ClInclude Include="GameComponent\StaticMeshComponent.h" />
     <ClInclude Include="Game\GameMgr.h" />
     <ClInclude Include="Game\InstanciateLevel.h" />
+    <ClInclude Include="Game\World.h" />
     <ClInclude Include="Objects\AssetObject.h" />
     <ClInclude Include="Objects\GameComponent.h" />
     <ClInclude Include="Objects\GameObject.h" />
@@ -99,6 +100,7 @@
     <ClCompile Include="GameComponent\TransformComponent.cpp" />
     <ClCompile Include="Game\GameMgr.cpp" />
     <ClCompile Include="Game\InstanciateLevel.cpp" />
+    <ClCompile Include="Game\World.cpp" />
     <ClCompile Include="Objects\AssetObject.cpp" />
     <ClCompile Include="Objects\GameComponent.cpp" />
     <ClCompile Include="Objects\GameObject.cpp" />

--- a/code/Systems/Systems.vcxproj.filters
+++ b/code/Systems/Systems.vcxproj.filters
@@ -60,6 +60,7 @@
     <ClInclude Include="Particle\ParticleSystem.h" />
     <ClInclude Include="Particle\ParticleEmitterRuntime.h" />
     <ClInclude Include="Rendering\Renderable\RenderableParticles.h" />
+    <ClInclude Include="Game\InstanciateLevel.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Assets\AssetMgr.cpp" />
@@ -106,6 +107,7 @@
     <ClCompile Include="Assets\AssetObjects\ParticleEffect\ParticleEmitter.cpp" />
     <ClCompile Include="Particle\ParticleSystem.cpp" />
     <ClCompile Include="Particle\ParticleEmitterRuntime.cpp" />
+    <ClCompile Include="Game\InstanciateLevel.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets\AssetRef\HardAssetRef.inl" />

--- a/code/Systems/Systems.vcxproj.filters
+++ b/code/Systems/Systems.vcxproj.filters
@@ -61,6 +61,7 @@
     <ClInclude Include="Particle\ParticleEmitterRuntime.h" />
     <ClInclude Include="Rendering\Renderable\RenderableParticles.h" />
     <ClInclude Include="Game\InstanciateLevel.h" />
+    <ClInclude Include="Game\World.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Assets\AssetMgr.cpp" />
@@ -108,6 +109,7 @@
     <ClCompile Include="Particle\ParticleSystem.cpp" />
     <ClCompile Include="Particle\ParticleEmitterRuntime.cpp" />
     <ClCompile Include="Game\InstanciateLevel.cpp" />
+    <ClCompile Include="Game\World.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets\AssetRef\HardAssetRef.inl" />

--- a/code/Systems/Systems.vcxproj.filters
+++ b/code/Systems/Systems.vcxproj.filters
@@ -62,6 +62,7 @@
     <ClInclude Include="Rendering\Renderable\RenderableParticles.h" />
     <ClInclude Include="Game\InstanciateLevel.h" />
     <ClInclude Include="Game\World.h" />
+    <ClInclude Include="Game\Subsystems\CameraSubsystem.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Assets\AssetMgr.cpp" />
@@ -110,6 +111,7 @@
     <ClCompile Include="Particle\ParticleEmitterRuntime.cpp" />
     <ClCompile Include="Game\InstanciateLevel.cpp" />
     <ClCompile Include="Game\World.cpp" />
+    <ClCompile Include="Game\Subsystems\CameraSubsystem.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets\AssetRef\HardAssetRef.inl" />


### PR DESCRIPTION
- Add a World containing pointers to subsystems.
- I can have multiple worlds (for example one for the level editor and one for the game).
- A world is a context in which levels are loaded.
- Make a camera subsystem and remove it from the GameMgr.